### PR TITLE
Fixed typos in README.md and install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Viewer will be deployed to on premise.
 
 ### Deploying using Docker Compose
 
-1. Your infra needs to have
+1. Your infrastructure needs to have
    [docker-compose v1.25 or newer](https://docs.docker.com/compose/install/) to
    run Viewer.
 2. [Login to the private registry](https://docs.docker.com/engine/reference/commandline/login/)

--- a/install.sh
+++ b/install.sh
@@ -147,6 +147,6 @@ fi
 $EXEC ${MANIFESTS[@]} config $@ > docker-compose.yaml
 
 echo
-echo "Application was configures"
+echo "Application was configured"
 echo "Launch with "
 echo "> docker-compose up"


### PR DESCRIPTION
Fixed typos: 
1. infra -> infrastucture in `README.md`
2. "was configures" -> "was configured" in `install.sh`